### PR TITLE
Fix relative links on old blog posts.

### DIFF
--- a/source/blog/accelerator-dataparallel.aspx.html
+++ b/source/blog/accelerator-dataparallel.aspx.html
@@ -10,9 +10,9 @@
 <p>If you've been following this article series, you already know 
   that Accelerator is a MSR library [<a href="#accelfsh3links">1</a>, <a href="#accelfsh3links">2</a>] 
   that allows you to run code in parallel on either multi-core CPU or using 
-  shaders on GPU (see <a href="accelerator-intro.aspx">introduction</a>).
+  shaders on GPU (see <a href="/blog/accelerator-intro.aspx">introduction</a>).
   We also discussed a direct way to use Accelerator from F# (by calling Accelerator methods
-  directly) and <a href="accelerator-life-game.aspx">implemented Conway's Game of Life</a>.
+  directly) and <a href="/blog/accelerator-life-game.aspx">implemented Conway's Game of Life</a>.
   In this article, we'll look at more sophisticated way of using Accelerator from F#.
   We'll introduce F# quotations and look at translating 'normal' F# code to use
   Accelerator.</p>
@@ -29,8 +29,8 @@
   writing code using quotations. Here is a list of articles in this series and of the
   articles that I'm planning to add:</p>
 <ul>
-  <li><a href="accelerator-intro.aspx">Accelerator and F# (I.): Introduction and calculating PI</a></li>
-  <li><a href="accelerator-life-game.aspx">Accelerator and F# (II.): The Game of Life on GPU</a></li>
+  <li><a href="/blog/accelerator-intro.aspx">Accelerator and F# (I.): Introduction and calculating PI</a></li>
+  <li><a href="/blog/accelerator-life-game.aspx">Accelerator and F# (II.): The Game of Life on GPU</a></li>
   <li><strong>Accelerator and F# (III.): Data-parallel programs using F# quotations</strong></li>
   <li><a href="http://tomasp.net/blog/accelerator-quotations.aspx">Accelerator and F# (IV.): Composing computations with quotations</a></li></ul>  
 

--- a/source/blog/accelerator-life-game.aspx.html
+++ b/source/blog/accelerator-life-game.aspx.html
@@ -6,7 +6,7 @@
       Description = "This article shows how to use Accelerator from F#, which I already discussed, to implement a massively parallel version of the famous Conway's Game of Life.";
     }<h1>Accelerator and F# (II.): The Game of Life on GPU</h1>
 <img src="/articles/accelerator-life-game/life.png" alt="Conway's Game of Life" style="float:right; margin:10px" />
-<p>In the <a href="accelerator-intro.aspx">previous article</a>, I introduced the
+<p>In the <a href="/blog/accelerator-intro.aspx">previous article</a>, I introduced the
   Microsoft Research Accelerator library. It allows us to write computations with arrays
   in C# and execute them in parallel on multi-core CPU or more interestingly, 
   using GPU shaders. In the previous artcile, we've seen how Accelerator works and 
@@ -23,7 +23,7 @@
   with Accelerator using F# quotations. The list of articles may change, but here is 
   a list of articles that I'm currently planning to write:</p>
 <ul>
-  <li><a href="accelerator-intro.aspx">Accelerator and F# (I.): Introduction and calculating PI</a></li>
+  <li><a href="/blog/accelerator-intro.aspx">Accelerator and F# (I.): Introduction and calculating PI</a></li>
   <li><strong>Accelerator and F# (II.): The Game of Life on GPU</strong></li>
   <li><a href="http://tomasp.net/blog/accelerator-dataparallel.aspx">Accelerator and F# (III.): Data-parallel programs using F# quotations</a></li>
   <li><a href="http://tomasp.net/blog/accelerator-quotations.aspx">Accelerator and F# (IV.): Composing computations with quotations</a></li></ul>  
@@ -63,7 +63,7 @@
   window is a multiple of the grid size. Once we know the size, we'll initialize
   a couple of <code>FloatParallelArray</code> instances representing arrays
   of the specified size that contain constant values. We're using the <code>FPA</code>
-  type alias from the <a href="accelerator-intro.aspx">previous article</a>.</p>
+  type alias from the <a href="/blog/accelerator-intro.aspx">previous article</a>.</p>
 
 <pre lang="fsharp">
 // Configuration of the game
@@ -105,7 +105,7 @@ let (==.) (a:FPA) (b:FPA) = PA.Cond(PA.CompareEqual(a, b), one, zero)
   dot to denote that they implement point-wise operations.</p>
 <p>The <code>rotate</code> function moves elements of the array by the specified 
   offset (it is a bit similar to <code>Shift</code> that we discussed in the 
-  <a href="accelerator-intro.aspx">previous article</a>). However, when elements
+  <a href="/blog/accelerator-intro.aspx">previous article</a>). However, when elements
   is shifted outside outside of the grid, values are copied back from 
   the other side. To demonstrate this, if we moved the contents of 1D array 
   <code>[1; 2; 3; 4; 5]</code> by +2, we'd get <code>[4; 5; 1; 2; 3]</code>.</p>

--- a/source/blog/fsharp-i-introduction.aspx.html
+++ b/source/blog/fsharp-i-introduction.aspx.html
@@ -54,9 +54,9 @@
   some of the most important .NET and F# library functions that make it possible.</p>
 <ul>
   <li>F# Overview (I.) - Introduction</li>
-  <li><a href="fsharp-ii-functional.aspx">F# Overview (II.) - Functional Programming</a></li>
-  <li><a href="fsharp-iii-oop.aspx">F# Overview (III.) - Object Oriented and Imperative Programming </a></li>
-  <li><a href="fsharp-iv-lang.aspx">F# Overview (IV.) - Language Oriented Programming</a></li>
+  <li><a href="/blog/fsharp-ii-functional.aspx">F# Overview (II.) - Functional Programming</a></li>
+  <li><a href="/blog/fsharp-iii-oop.aspx">F# Overview (III.) - Object Oriented and Imperative Programming </a></li>
+  <li><a href="/blog/fsharp-iv-lang.aspx">F# Overview (IV.) - Language Oriented Programming</a></li>
 </ul>  
 <ul>
   <li>You can also download the complete article as <a href="/articles/fsharp-i-introduction/article.pdf">a single document</a> (PDF).</li>

--- a/source/blog/fsharp-ii-functional.aspx.html
+++ b/source/blog/fsharp-ii-functional.aspx.html
@@ -5,7 +5,7 @@
       Date = "11/3/2007 12:00:02 AM";
       Description = "In the second part of the F# overview we will look at functional programming, which is probably the most important paradigm used with the F# language, because F# is built on the same grounds as many functional languages.";
     }<h1>F# Overview (II.) - Functional Programming</h1>
-<p>As already mentioned in the <a href="fsharp-i-introduction.aspx">Introduction</a> for this article series,
+<p>As already mentioned in the <a href="/blog/fsharp-i-introduction.aspx">Introduction</a> for this article series,
   F# is a typed functional language, by which I mean that types of all values are determined during the compile-time. 
   However, thanks to the use of a <em>type inference</em>, the types are explicitly specified in the code very rarely as we will see in the 
   following examples. The type inference means that the compiler deduces the type from the code, so for example
@@ -331,8 +331,8 @@ val it : unit </pre>
 
 <h2>Article Series Links</h2>
 <ul>
-  <li><a href="fsharp-i-introduction.aspx">F# Overview (I.) - Introduction</a></li>
+  <li><a href="/blog/fsharp-i-introduction.aspx">F# Overview (I.) - Introduction</a></li>
   <li>F# Overview (II.) - Functional Programming</li>
-  <li><a href="fsharp-iii-oop.aspx">F# Overview (III.) - Object Oriented and Imperative Programming </a></li>
-  <li><a href="fsharp-iv-lang.aspx">F# Overview (IV.) - Language Oriented Programming</a></li>
+  <li><a href="/blog/fsharp-iii-oop.aspx">F# Overview (III.) - Object Oriented and Imperative Programming </a></li>
+  <li><a href="/blog/fsharp-iv-lang.aspx">F# Overview (IV.) - Language Oriented Programming</a></li>
 </ul>  

--- a/source/blog/fsharp-iii-oop.aspx.html
+++ b/source/blog/fsharp-iii-oop.aspx.html
@@ -6,7 +6,7 @@
       Description = "In the third part of the F# overview, we will look at the F# features that are essential for a smooth interoperability with other .NET languages and form a second part of the F# core language - that is object oriented and imperative programming.";
     }<h1>F# Overview (III.) - Imperative and Object-Oriented Programming</h1>
 <p>In the third part of the F# Overview article series, we will look at language features that are mostly well known, because they are present in most of the currently used programming languages. Indeed, I'm talking about imperative programming, which is a common way for storing and manipulating application data and about object oriented programming which is used for structuring complex programs.</p>
-<p>In general, F# tries to make using them together with the functional constructs described in the <a href="fsharp-ii-functional.aspx">previous part</a> [<a href="fsharp-ii-functional.aspx" target="_blank">^</a>] as natural as possible, which yields several very powerful constructs.</p>
+<p>In general, F# tries to make using them together with the functional constructs described in the <a href="/blog/fsharp-ii-functional.aspx">previous part</a> [<a href="/blog/fsharp-ii-functional.aspx" target="_blank">^</a>] as natural as possible, which yields several very powerful constructs.</p>
 
 <h2>Imperative Programming and Mutable Values</h2>
 <p>Similarly as ML and OCaml, F# adopts an <em>eager evaluation</em> mechanism, which means that a code written using
@@ -235,8 +235,8 @@ val it : list&lt;int&gt; = [ 1; 2 ]
 
 <h2>Article Series Links</h2>
 <ul>
-  <li><a href="fsharp-i-introduction.aspx">F# Overview (I.) - Introduction</a></li>
-  <li><a href="fsharp-ii-functional.aspx">F# Overview (II.) - Functional Programming</a></li>
+  <li><a href="/blog/fsharp-i-introduction.aspx">F# Overview (I.) - Introduction</a></li>
+  <li><a href="/blog/fsharp-ii-functional.aspx">F# Overview (II.) - Functional Programming</a></li>
   <li>F# Overview (III.) - Object Oriented and Imperative Programming</li>
-  <li><a href="fsharp-iv-lang.aspx">F# Overview (IV.) - Language Oriented Programming</a></li>
+  <li><a href="/blog/fsharp-iv-lang.aspx">F# Overview (IV.) - Language Oriented Programming</a></li>
 </ul>  

--- a/source/blog/fsharp-iv-lang.aspx.html
+++ b/source/blog/fsharp-iv-lang.aspx.html
@@ -22,8 +22,8 @@
   that it is a separate language (e.g. a XML file) or an <em>internal</em>, meaning that it is written using a subset of the host language.
   Using this terminology, we will focus on writing <em>internal DSLs</em> in F#.</p>  
 <p>Since this term is not as widely used as functional or object oriented programming which we discussed in earlier articles in this series
-  (<a href="fsharp-ii-functional.aspx">Functional Programming</a> [<a href="fsharp-ii-functional.aspx">^</a>], 
-   <a href="fsharp-iii-oop.aspx">Object Oriented and Imperative Programming</a> [<a href="fsharp-iii-oop.aspx">^</a>]), let me 
+  (<a href="/blog/fsharp-ii-functional.aspx">Functional Programming</a> [<a href="/blog/fsharp-ii-functional.aspx">^</a>], 
+   <a href="/blog/fsharp-iii-oop.aspx">Object Oriented and Imperative Programming</a> [<a href="/blog/fsharp-iii-oop.aspx">^</a>]), let me 
    very quickly introduce why I believe that this is an important topic. I think the main reason why language oriented
    development is appealing paradigm is that it allows very smooth cooperation of people working on the project - 
    there are people who develop the language and those who use it. The language developers need to have advanced 
@@ -449,9 +449,9 @@ let rec eval x =
 
 <h2>Article Series Links</h2>
 <ul>
-  <li><a href="fsharp-i-introduction.aspx">F# Overview (I.) - Introduction</a></li>
-  <li><a href="fsharp-ii-functional.aspx">F# Overview (II.) - Functional Programming</a></li>
-  <li><a href="fsharp-iii-oop.aspx">F# Overview (III.) - Object Oriented and Imperative Programming </a></li>
+  <li><a href="/blog/fsharp-i-introduction.aspx">F# Overview (I.) - Introduction</a></li>
+  <li><a href="/blog/fsharp-ii-functional.aspx">F# Overview (II.) - Functional Programming</a></li>
+  <li><a href="/blog/fsharp-iii-oop.aspx">F# Overview (III.) - Object Oriented and Imperative Programming </a></li>
   <li>F# Overview (IV.) - Language Oriented Programming</li>
 </ul>  
 

--- a/source/blog/fsharp-webcast-async.aspx.html
+++ b/source/blog/fsharp-webcast-async.aspx.html
@@ -6,8 +6,8 @@
       Description = "In the previous part you've seen how to write a simple function for downloading RSS feeds and processing them. In this part, we look how to improve the function to download data asynchronously and process them potentially in parallel.";
     }<h1>F# Webcast (III.) - Using Asynchronous Workflows</h1>
 <p>In this webcast, we'll look at improving the code for downloading and
-  processing RSS feeds that I presented in <a href="fsharp-webcast-dotnet.aspx">the second part</a> 
-  (if you didn't see earlier parts, <a href="fsharp-webcast-dotnet.aspx">the first one</a> was an introduction to 
+  processing RSS feeds that I presented in <a href="/blog/fsharp-webcast-dotnet.aspx">the second part</a> 
+  (if you didn't see earlier parts, <a href="/blog/fsharp-webcast-dotnet.aspx">the first one</a> was an introduction to 
   basic functional ideas). The previous part demonstrated how to use .NET libraries
   and we implemented a simple <code>downloadUrl</code> function for obtaining content
   of from the web and we've also seen how to load the data into an XML document object
@@ -41,12 +41,12 @@
   and finally, we can also encapsulate it into a standard .NET library that's usable from C#. 
   Here is a list of all webcasts in the series:</p>
 <ul>
-  <li style="margin-bottom:5px;"><strong><a href="fsharp-webcast-functional.aspx">Part I. - Introducing functional concepts</a></strong><br />
+  <li style="margin-bottom:5px;"><strong><a href="/blog/fsharp-webcast-functional.aspx">Part I. - Introducing functional concepts</a></strong><br />
     The first part introduces functional programming principles such as immutability, recursion and functions
     that take other functions as parameter (<em>higher order</em> functions). This can all be demonstrated in
     C# 3.0, so we start with C# and then look how the same concepts look in F#. Finally, the first part also
     shows functions for working with lists in F#.</li>
-  <li style="margin-bottom:5px;"><strong><a href="fsharp-webcast-dotnet.aspx">Part II. - Using standard .NET libraries</a></strong><br />
+  <li style="margin-bottom:5px;"><strong><a href="/blog/fsharp-webcast-dotnet.aspx">Part II. - Using standard .NET libraries</a></strong><br />
     The second part demonstrates how we can use standard .NET libraries. It uses classes from <code>System.Net</code>
     and <code>System.Xml</code> to download content of a web page (RSS feed), load it into XML document and 
     process it to find only posts that contain some specified keyword.</li>
@@ -54,7 +54,7 @@
     The third part shows how to make the code from the part II. better. It introduces F# <em>asynchronous workflows</em>
     that can be used for writing code that doesn't block a thread when waiting for the completion of some I/O request.
     This part also shows how to modify the code to download and process multiple feeds in parallel.</li>
-  <li style="margin-bottom:5px;"><strong><a href="fsharp-webcast-objects.aspx">Part IV. - Developing standard .NET libraries</a></strong><br />
+  <li style="margin-bottom:5px;"><strong><a href="/blog/fsharp-webcast-objects.aspx">Part IV. - Developing standard .NET libraries</a></strong><br />
     In the fourth part, we look how to encapsulate the functionality written in F# into classes. 
     We'll finally create a project (rather than just use F# scripts) and we'll wrap the code we wrote into
     a .NET class. We'll also look how to compile the project into DLL and how to use it from a simple C# web application.</li>

--- a/source/blog/fsharp-webcast-dotnet.aspx.html
+++ b/source/blog/fsharp-webcast-dotnet.aspx.html
@@ -5,7 +5,7 @@
       Date = "6/1/2009 2:57:53 PM";
       Description = "This is the second part of the webcast series that introduces the F# language. It shows how to use .NET libraries from F# to download RSS feed and how to work with the obtained data using tuples, sequence expressions and other F# features.";
     }<h1>F# Webcast (II.) - Using .NET libraries</h1>
-<p>About a week ago I posted <a href="fsharp-webcast-functional.aspx">the first part</a> of my F# webcast series.
+<p>About a week ago I posted <a href="/blog/fsharp-webcast-functional.aspx">the first part</a> of my F# webcast series.
   It focused on explainining the basic ideas behind functional programming such as immutability, recursion
   and passing functions as arguments to other functions (or methods in C#). In the first part, we've seen some
   C# code to demonstrate the ideas and also a bit of F#, mainly to show the basic language features.
@@ -31,7 +31,7 @@
   and finally, we can also encapsulate it into a standard .NET library that's usable from C#. 
   Here is a list of all webcasts in the series:</p>
 <ul>
-  <li style="margin-bottom:5px;"><strong><a href="fsharp-webcast-functional.aspx">Part I. - Introducing functional concepts</a></strong><br />
+  <li style="margin-bottom:5px;"><strong><a href="/blog/fsharp-webcast-functional.aspx">Part I. - Introducing functional concepts</a></strong><br />
     The first part introduces functional programming principles such as immutability, recursion and functions
     that take other functions as parameter (<em>higher order</em> functions). This can all be demonstrated in
     C# 3.0, so we start with C# and then look how the same concepts look in F#. Finally, the first part also
@@ -40,11 +40,11 @@
     The second part demonstrates how we can use standard .NET libraries. It uses classes from <code>System.Net</code>
     and <code>System.Xml</code> to download content of a web page (RSS feed), load it into XML document and 
     process it to find only posts that contain some specified keyword.</li>
-  <li style="margin-bottom:5px;"><strong><a href="fsharp-webcast-async.aspx">Part III. - Downloading web pages asynchronously</a></strong><br />
+  <li style="margin-bottom:5px;"><strong><a href="/blog/fsharp-webcast-async.aspx">Part III. - Downloading web pages asynchronously</a></strong><br />
     The third part shows how to make the code from the part II. better. It introduces F# <em>asynchronous workflows</em>
     that can be used for writing code that doesn't block a thread when waiting for the completion of some I/O request.
     This part also shows how to modify the code to download and process multiple feeds in parallel.</li>
-  <li style="margin-bottom:5px;"><strong><a href="fsharp-webcast-objects.aspx">Part IV. - Developing standard .NET libraries</a></strong><br />
+  <li style="margin-bottom:5px;"><strong><a href="/blog/fsharp-webcast-objects.aspx">Part IV. - Developing standard .NET libraries</a></strong><br />
     In the fourth part, we look how to encapsulate the functionality written in F# into classes. 
     We'll finally create a project (rather than just use F# scripts) and we'll wrap the code we wrote into
     a .NET class. We'll also look how to compile the project into DLL and how to use it from a simple C# web application.</li>

--- a/source/blog/fsharp-webcast-functional.aspx.html
+++ b/source/blog/fsharp-webcast-functional.aspx.html
@@ -41,15 +41,15 @@
     that take other functions as parameter (<em>higher order</em> functions). This can all be demonstrated in
     C# 3.0, so we start with C# and then look how the same concepts look in F#. Finally, the first part also
     shows functions for working with lists in F#.</li>
-  <li style="margin-bottom:5px;"><strong><a href="fsharp-webcast-dotnet.aspx">Part II. - Using standard .NET libraries</a></strong><br />
+  <li style="margin-bottom:5px;"><strong><a href="/blog/fsharp-webcast-dotnet.aspx">Part II. - Using standard .NET libraries</a></strong><br />
     The second part demonstrates how we can use standard .NET libraries. It uses classes from <code>System.Net</code>
     and <code>System.Xml</code> to download content of a web page (RSS feed), load it into XML document and 
     process it to find only posts that contain some specified keyword.</li>
-  <li style="margin-bottom:5px;"><strong><a href="fsharp-webcast-async.aspx">Part III. - Downloading web pages asynchronously</a></strong><br />
+  <li style="margin-bottom:5px;"><strong><a href="/blog/fsharp-webcast-async.aspx">Part III. - Downloading web pages asynchronously</a></strong><br />
     The third part shows how to make the code from the part II. better. It introduces F# <em>asynchronous workflows</em>
     that can be used for writing code that doesn't block a thread when waiting for the completion of some I/O request.
     This part also shows how to modify the code to download and process multiple feeds in parallel.</li>
-  <li style="margin-bottom:5px;"><strong><a href="fsharp-webcast-objects.aspx">Part IV. - Developing standard .NET libraries</a></strong><br />
+  <li style="margin-bottom:5px;"><strong><a href="/blog/fsharp-webcast-objects.aspx">Part IV. - Developing standard .NET libraries</a></strong><br />
     In the fourth part, we look how to encapsulate the functionality written in F# into classes. 
     We'll finally create a project (rather than just use F# scripts) and we'll wrap the code we wrote into
     a .NET class. We'll also look how to compile the project into DLL and how to use it from a simple C# web application.</li>

--- a/source/blog/fsharp-webcast-objects.aspx.html
+++ b/source/blog/fsharp-webcast-objects.aspx.html
@@ -7,10 +7,10 @@
     }<h1>F# Webcast (IV.) - Developing standard .NET libraries</h1>
 <p>In the previous parts of this webcast series we've developed an F# script that downloads RSS feeds
   asynchronously and in parallel and searches them for the specified keywords. We followed the usual F#
-  development style, so after introducing <a href="fsharp-webcast-functional.aspx">the basic functional 
-  concepts</a>, we wrote the code in <a href="fsharp-webcast-dotnet.aspx">the simples possible style</a> 
+  development style, so after introducing <a href="/blog/fsharp-webcast-functional.aspx">the basic functional 
+  concepts</a>, we wrote the code in <a href="/blog/fsharp-webcast-dotnet.aspx">the simples possible style</a> 
   and demonstrated how to use <code>System.Xml</code> and <code>System.Net</code> namespaces. Then we 
-  <a href="fsharp-webcast-async.aspx">refactored the existing code</a>, to run asynchronously and process
+  <a href="/blog/fsharp-webcast-async.aspx">refactored the existing code</a>, to run asynchronously and process
   the results potentially in parallel, which was very easy thanks to F# <em>asynchronous workflows</em>.</p>
 
 <p>In this part of the series, we'll make the next evolutionary step of our sample application. We'll turn
@@ -18,7 +18,7 @@
   also see how to declare a class in F#. This simple modification will turn the script into an F# library
   that is almost indistinguishable from a library developed in C#. We'll also look how you can use the library
   from C# web application to show the interop between C# and F# in practice. We'll start
-  with the code from the <a href="fsharp-webcast-async.aspx">previous part</a>, so if you missed that, you
+  with the code from the <a href="/blog/fsharp-webcast-async.aspx">previous part</a>, so if you missed that, you
   may want to check it out or download the source code.</p>
 
 <div style="text-align:center">
@@ -36,16 +36,16 @@
   and finally, we can also encapsulate it into a standard .NET library that's usable from C#. 
   Here is a list of all webcasts in the series:</p>
 <ul>
-  <li style="margin-bottom:5px;"><strong><a href="fsharp-webcast-functional.aspx">Part I. - Introducing functional concepts</a></strong><br />
+  <li style="margin-bottom:5px;"><strong><a href="/blog/fsharp-webcast-functional.aspx">Part I. - Introducing functional concepts</a></strong><br />
     The first part introduces functional programming principles such as immutability, recursion and functions
     that take other functions as parameter (<em>higher order</em> functions). This can all be demonstrated in
     C# 3.0, so we start with C# and then look how the same concepts look in F#. Finally, the first part also
     shows functions for working with lists in F#.</li>
-  <li style="margin-bottom:5px;"><strong><a href="fsharp-webcast-dotnet.aspx">Part II. - Using standard .NET libraries</a></strong><br />
+  <li style="margin-bottom:5px;"><strong><a href="/blog/fsharp-webcast-dotnet.aspx">Part II. - Using standard .NET libraries</a></strong><br />
     The second part demonstrates how we can use standard .NET libraries. It uses classes from <code>System.Net</code>
     and <code>System.Xml</code> to download content of a web page (RSS feed), load it into XML document and 
     process it to find only posts that contain some specified keyword.</li>
-  <li style="margin-bottom:5px;"><strong><a href="fsharp-webcast-async.aspx">Part III. - Downloading web pages asynchronously</a></strong><br />
+  <li style="margin-bottom:5px;"><strong><a href="/blog/fsharp-webcast-async.aspx">Part III. - Downloading web pages asynchronously</a></strong><br />
     The third part shows how to make the code from the part II. better. It introduces F# <em>asynchronous workflows</em>
     that can be used for writing code that doesn't block a thread when waiting for the completion of some I/O request.
     This part also shows how to modify the code to download and process multiple feeds in parallel.</li>

--- a/source/blog/reactive-i-fsevents.aspx.html
+++ b/source/blog/reactive-i-fsevents.aspx.html
@@ -193,9 +193,9 @@ evtMessages
 <h3>Series links</h3>
 <ul>
   <li>Reactive programming (I.) - First class events in F#</li>
-  <li><a href="reactive-ii-csevents.aspx">Reactive programming (II.) - Introducing Reactive LINQ</a></li>
-  <li><a href="reactive-iii-linqoperators.aspx">Reactive Programming (III.) - Useful Reactive LINQ Operators</a></li>
-  <li><a href="reactive-iv-reactivegame.aspx">Reactive Programming (IV.) - Developing reactive game in Reactive LINQ</a></li>
+  <li><a href="/blog/reactive-ii-csevents.aspx">Reactive programming (II.) - Introducing Reactive LINQ</a></li>
+  <li><a href="/blog/reactive-iii-linqoperators.aspx">Reactive Programming (III.) - Useful Reactive LINQ Operators</a></li>
+  <li><a href="/blog/reactive-iv-reactivegame.aspx">Reactive Programming (IV.) - Developing reactive game in Reactive LINQ</a></li>
 </ul>
 
 

--- a/source/blog/reactive-ii-csevents.aspx.html
+++ b/source/blog/reactive-ii-csevents.aspx.html
@@ -9,7 +9,7 @@
   by the ideas that come from functional reactive programming in the Haskell language and from 
   functionality that's available for working in events in F#. I introduced these ideas in my previous article
   in this mini-series, so if you're interested in learning more about these interesting technologies, you 
-  should definitely read the previous article about <a href="reactive-i-fsevents.aspx">First class events in F#</a>.</p>
+  should definitely read the previous article about <a href="/blog/reactive-i-fsevents.aspx">First class events in F#</a>.</p>
 <p>In this article, we're going to look how to apply the same ideas to the C# language and how 
   to use LINQ queries for processing events. This article is <a href="http://tomasp.net/blog/dynamic-linq-queries.aspx">just</a>&#160;<a href="http://tomasp.net/blog/csharp-async.aspx">another</a> my article that shows how to implement some 
   idea from functional programming in C#. I believe this will once again show that the new features
@@ -216,10 +216,10 @@ eMerged.First().Listen(str =&gt; MessageBox.Show(str));
 
 <h3>Series links</h3>
 <ul>
-  <li><a href="reactive-i-fsevents.aspx">Reactive programming (I.) - First class events in F#</a></li>
+  <li><a href="/blog/reactive-i-fsevents.aspx">Reactive programming (I.) - First class events in F#</a></li>
   <li>Reactive programming (II.) - Introducing Reactive LINQ</li>
-  <li><a href="reactive-iii-linqoperators.aspx">Reactive Programming (III.) - Useful Reactive LINQ Operators</a></li>
-  <li><a href="reactive-iv-reactivegame.aspx">Reactive Programming (IV.) - Developing reactive game in Reactive LINQ</a></li>
+  <li><a href="/blog/reactive-iii-linqoperators.aspx">Reactive Programming (III.) - Useful Reactive LINQ Operators</a></li>
+  <li><a href="/blog/reactive-iv-reactivegame.aspx">Reactive Programming (IV.) - Developing reactive game in Reactive LINQ</a></li>
 </ul>
 
 <h2>References<a name="react2links"></a></h2>

--- a/source/blog/reactive-iii-linqoperators.aspx.html
+++ b/source/blog/reactive-iii-linqoperators.aspx.html
@@ -5,7 +5,7 @@
       Date = "11/21/2008 7:59:02 PM";
       Description = "In the previous article, I introduced Reactive LINQ. Today, we're going to look at other operators that canbe used for working with events. We'll see aggregation is useful and how to dynamically change (switch) behavior.";
     }<h1>Reactive Programming (III.) - Useful Reactive LINQ Operators</h1>
-<p>In the <a href="reactive-ii-csevents.aspx">previous article</a>, I introduced <strong>Reactive LINQ</strong>.
+<p>In the <a href="/blog/reactive-ii-csevents.aspx">previous article</a>, I introduced <strong>Reactive LINQ</strong>.
   I explained the different point of view that we can use when working with .NET events. The idea is that
   .NET events can be viewed as streams of values. The value is information about the event (such as position
   of a mouse click or a mouse movement). These streams can be processed using LINQ queries - we can for example
@@ -19,7 +19,7 @@
   application behaves. However, I'll explain this in a more detail soon.</p>
 <p>In this article, I'm going to use mostly C# (and some Visual Basic). The functionality that I'm describing
   in this part isn't part of the standard F# <code>Event</code> module that I discussed in 
-  <a href="reactive-i-fsevents.aspx">the first part</a>. I implemented most of them in F# too, but I'm not going
+  <a href="/blog/reactive-i-fsevents.aspx">the first part</a>. I implemented most of them in F# too, but I'm not going
   to write the samples in both of the versions in this part. If you've seen the first two articles, you'll be 
   definitely able to use the F# versions as well, because they follow exactly the same ideas as the C#/LINQ versions.
   I'm going to talk about a larger demo application in the last section and I'll show an F# version as well,
@@ -402,8 +402,8 @@ var eDecrementClick = Reactive.Merge
 
 <h3>Series links</h3>
 <ul>
-  <li><a href="reactive-i-fsevents.aspx">Reactive programming (I.) - First class events in F#</a></li>
-  <li><a href="reactive-ii-csevents.aspx">Reactive programming (II.) - Introducing Reactive LINQ</a></li>
+  <li><a href="/blog/reactive-i-fsevents.aspx">Reactive programming (I.) - First class events in F#</a></li>
+  <li><a href="/blog/reactive-ii-csevents.aspx">Reactive programming (II.) - Introducing Reactive LINQ</a></li>
   <li>Reactive Programming (III.) - Useful Reactive LINQ Operators</li>
-  <li><a href="reactive-iv-reactivegame.aspx">Reactive Programming (IV.) - Developing reactive game in Reactive LINQ</a></li>
+  <li><a href="/blog/reactive-iv-reactivegame.aspx">Reactive Programming (IV.) - Developing reactive game in Reactive LINQ</a></li>
 </ul>

--- a/source/blog/reactive-iv-reactivegame.aspx.html
+++ b/source/blog/reactive-iv-reactivegame.aspx.html
@@ -7,10 +7,10 @@
     }<h1>Reactive Programming (IV.) - Developing a game in Reactive LINQ</h1>
 <p>In this part of the article series about <strong>Reactive LINQ</strong>we're going to 
   implement a slightly more complicated application using the library that I introduced
-  in the previous three articles. We're going to use basic event stream queries from the <a href="reactive-ii-csevents.aspx">second article</a> 
-  as well as advanced operators introduced in the <a href="reactive-iii-linqoperators.aspx">third part</a>.
+  in the previous three articles. We're going to use basic event stream queries from the <a href="/blog/reactive-ii-csevents.aspx">second article</a> 
+  as well as advanced operators introduced in the <a href="/blog/reactive-iii-linqoperators.aspx">third part</a>.
   This time, I'll also show the F# version of all the examples, so we're going to build on the ideas from
-  the <a href="reactive-i-fsevents.aspx">first part</a>.</p>
+  the <a href="/blog/reactive-i-fsevents.aspx">first part</a>.</p>
 
 <p>I originally wanted to write the demo only in Visual Basic, because I think that
   it is really amazig to show an idea that came from functional programming in a language
@@ -112,7 +112,7 @@ let eClicked =
 <p>As a next step, we'll implement moving of the smiley. The smiley moves when the user clicks on it,
   so we'll need to use the event <code>eClicked</code> from the previous listing. However, the smiley
   also moves after 600ms if the user hasn't clicked on it yet. This is quite similar to one of the examples
-  from the <a href="reactive-iii-linqoperators.aspx">previous article</a> - the one where we were displaying 
+  from the <a href="/blog/reactive-iii-linqoperators.aspx">previous article</a> - the one where we were displaying 
   "Click..." and "Timeout!" messages.</p>
 <p>We'll need to use one of the switching operators. We want to generate a new event stream every time 
   an event occurs, to make sure that the timer will start counting from zero. This can be done using
@@ -269,9 +269,9 @@ Reactive.Repeatedly(1000.0)
 
 <h3>Series links</h3>
 <ul>
-  <li><a href="reactive-i-fsevents.aspx">Reactive programming (I.) - First class events in F#</a></li>
-  <li><a href="reactive-ii-csevents.aspx">Reactive programming (II.) - Introducing Reactive LINQ</a></li>
-  <li><a href="reactive-iii-linqoperators.aspx">Reactive Programming (III.) - Useful Reactive LINQ Operators</a></li>
+  <li><a href="/blog/reactive-i-fsevents.aspx">Reactive programming (I.) - First class events in F#</a></li>
+  <li><a href="/blog/reactive-ii-csevents.aspx">Reactive programming (II.) - Introducing Reactive LINQ</a></li>
+  <li><a href="/blog/reactive-iii-linqoperators.aspx">Reactive Programming (III.) - Useful Reactive LINQ Operators</a></li>
   <li>Reactive Programming (IV.) - Developing reactive game in Reactive LINQ</li>
 </ul>
 


### PR DESCRIPTION
Those weren't working because the web server appends a '/'
at the end of the url, making links relative to the current
page not work as expected.