### PR TITLE
Get rid of misleading symmetry in StateUpdate.Combine

### DIFF
--- a/source/blog/2014/update-monads.fsx
+++ b/source/blog/2014/update-monads.fsx
@@ -451,8 +451,8 @@ type StateUpdate<'T> =
   /// Combine updates - return the latest (rightmost) 'Set' update
   static member Combine(a, b) = 
     match a, b with 
-    | SetNop, v | v, SetNop -> v 
-    | Set a, Set b -> Set b
+    | v, SetNop -> v 
+    | _, Set b -> Set b
   /// Apply update to a state - the 'Set' update changes the state
   static member Apply(s, p) = 
     match p with SetNop -> s | Set s -> State s


### PR DESCRIPTION
Hi Tomas, I just read your excellent post on the update monad. I stumbled for a few long minutes, though, trying to understand why a \circ b of the `StateUpdate` is so symmetrical unless both a and b are not noops, before I realized it actually isn't! May I suggest a rewrite in this explicitly asymmetric form? To me, this form seems easier to understand: left to right, `SetNop` passes `v` through, but `Set b` prevails.

Technically, the second case could have been written as `| _, v -> v`, but that would be didactically wrong, I think :)