### PR TITLE
updated style.css

### DIFF
--- a/content/custom/style.css
+++ b/content/custom/style.css
@@ -28,9 +28,11 @@
 
 /* Customize how the navigation bar looks */
 .top-bar-header ul, .top-bar-header li, .top-bar-header nav, .top-bar-header div {
-  background:white;
+  background: transparent;
 }
+
 .top-bar-header nav {
+  background: white;
   border-bottom:4px solid black;
   height:40px;
   overflow:hidden;


### PR DESCRIPTION
Body text is no longer covered by the sticky nav bar's bottom margin.

Before:
![before](https://img.ourl.ca/before.png)

After:
![after](https://img.ourl.ca/after.png)